### PR TITLE
Fixed Undeclared global variable QoS error

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,8 +15,7 @@ monitoring = {
   }
 }
 
-local http = QoS and QoS(minetest.request_http_api(), 2) or minetest.request_http_api()
-local MP = minetest.get_modpath("monitoring")
+local http = minetest.get_modpath("qos") and QoS and QoS(minetest.request_http_api(), 2) or minetest.request_http_api()
 
 dofile(MP.."/metrictypes/gauge.lua")
 dofile(MP.."/metrictypes/counter.lua")

--- a/init.lua
+++ b/init.lua
@@ -16,6 +16,7 @@ monitoring = {
 }
 
 local http = minetest.get_modpath("qos") and QoS and QoS(minetest.request_http_api(), 2) or minetest.request_http_api()
+local MP = minetest.get_modpath("monitoring")
 
 dofile(MP.."/metrictypes/gauge.lua")
 dofile(MP.."/metrictypes/counter.lua")


### PR DESCRIPTION
Fixed the Warning message in console: 

2021-08-24 07:32:18: WARNING[Main]: Undeclared global variable "QoS" accessed at /home/minetest/minetest/mods/monitoring/init.lua:18