### PR TITLE
New forceload counting mechanic

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,17 +1,10 @@
 name: luacheck
-
 on: [push, pull_request]
-
 jobs:
-  build:
-
+  luacheck:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-    - name: apt
-      run: sudo apt-get install -y luarocks
-    - name: luacheck install
-      run: luarocks install --local luacheck
-    - name: luacheck run
-      run: $HOME/.luarocks/bin/luacheck ./
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Luacheck
+        uses: lunarmodules/luacheck@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,7 @@
 name: test
-
 on: [push, pull_request]
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -12,7 +9,7 @@ jobs:
         ENGINE_VERSION: [5.3.0, 5.4.0, 5.5.0, 5.6.1, 5.7.0, latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
       with:
         fetch-depth: 0
         submodules: recursive

--- a/builtin/forceload_blocks.lua
+++ b/builtin/forceload_blocks.lua
@@ -53,3 +53,27 @@ end
 minetest.register_on_mods_loaded(function()
 	update_metric()
 end)
+
+-- minetest doesn't call the global api on startup
+
+local wpath = minetest.get_worldpath()
+
+-- stolen from https://github.com/minetest/minetest/blob/master/builtin/game/forceloading.lua
+local function read_file(filename)
+	local f = io.open(filename, "r")
+	if f == nil then return {} end
+	local t = f:read("*all")
+	f:close()
+	if t == "" or t == nil then return {} end
+
+	return minetest.deserialize(t) or {}
+end
+
+local forceloadedtxt = read_file(wpath.."/force_loaded.txt")
+
+minetest.after(5, function()
+	for hash, _ in pairs(forceloadedtxt) do
+		blocks_forceloaded[hash] = true
+	end
+	update_metric()
+end)

--- a/builtin/forceload_blocks.lua
+++ b/builtin/forceload_blocks.lua
@@ -49,3 +49,7 @@ function monitoring.is_forceloaded(pos)
 	local hash = minetest.hash_node_position(blockpos)
 	return blocks_forceloaded[hash] == true
 end
+
+minetest.register_on_mods_loaded(function()
+	update_metric()
+end)


### PR DESCRIPTION
- Workflow cleanup
- Count forceloaded blocks by wrapping API calls (closes https://github.com/minetest-monitoring/monitoring/issues/23)
Not tested yet :smile: 