### PR TITLE
Fix crash when calling `minetest.log()` w/ one arg

### DIFF
--- a/builtin/log.lua
+++ b/builtin/log.lua
@@ -4,5 +4,10 @@ local old_log = minetest.log
 
 function minetest.log(level, text)
     metric.inc()
-    return old_log(level, text)
+    -- The number and order of parameters is important here
+    if text ~= nil then
+        return old_log(level, text)
+    else
+        return old_log(level)
+    end
 end


### PR DESCRIPTION
Trigger:
```lua
minetest.log("foo")
```