### PR TITLE
update basic_machines mod

### DIFF
--- a/mods/basic_machines/init.lua
+++ b/mods/basic_machines/init.lua
@@ -12,15 +12,13 @@ local function register_effector_metric(nodename, metricname, prettyname)
 	if nodedef.effector and nodedef.effector.action_on then
 		nodedef.effector.action_on = metric_count.wrap( metric_time.wraptime(nodedef.effector.action_on) )
 	end
-	if nodedef.mesecons and nodedef.mesecons.effector and nodedef.mesecons.effector.action_on then
-		nodedef.mesecons.effector.action_on = metric_count.wrap( metric_time.wraptime(nodedef.mesecons.effector.action_on) )
-	end
 end
 
+register_effector_metric("basic_machines:autocrafter", "autocrafter", "Autocrafter")
+register_effector_metric("basic_machines:ball_spawner", "ball_spawner", "Ball Spawner")
 register_effector_metric("basic_machines:mover", "mover", "Mover")
 register_effector_metric("basic_machines:keypad", "keypad", "Keypad")
 register_effector_metric("basic_machines:detector", "detector", "Detector")
-register_effector_metric("basic_machines:clockgen", "clockgen", "Clockgen")
 register_effector_metric("basic_machines:distributor", "distributor", "Distributor")
 register_effector_metric("basic_machines:light_off", "light_off", "Light off")
 register_effector_metric("basic_machines:light_on", "light_on", "Light on")


### PR DESCRIPTION
the clockgen is using ABM, there are only nodedef.effector.action_on and action_off for some machines, probably not useful to add all of them? thanks
edit: 
only basic_machines:mesecon_adapter is having mesecons table
https://github.com/waxtatect/basic_machines/blob/14986c2f169c947c310ed7708d0cf5523a341f25/mesecon_adapter.lua#L69